### PR TITLE
Fix centering issue in Safari.

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,6 +74,7 @@ a:hover {
 .center {
     position:absolute;
     left:50%;
+    -webkit-transform: translate(-50%,0);
     transform:translate(-50%,0)
 }
 


### PR DESCRIPTION
Safari still needs `-webkit-` prefix for the moment.
